### PR TITLE
remove from entries polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,11 +38,9 @@
     },
     "devDependencies": {
         "@types/jest": "^26.0.14",
-        "@types/object.fromentries": "^2.0.0",
         "bundlesize": "^0.18.0",
         "figma-js": "^1.13.0",
         "husky": "^4.3.0",
-        "object.fromentries": "^2.0.2",
         "tsdx": "^0.14.0",
         "typescript": "3.9.7"
     },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,4 @@
 import { Node } from "figma-js";
-import fromEntries from "object.fromentries";
 import { Shortcuts, ShortcutType } from "./types";
 
 export function uniqBy(arr: any[], key: string) {
@@ -37,7 +36,7 @@ export const parseShortcutKeys = (obj: Record<string, any>): Shortcuts => {
         STYLE: "styles",
     };
 
-    return fromEntries(
+    return Object.fromEntries(
         Object.entries(obj).map(([k, v]) => [mapKeys[k as ShortcutType], v])
     ) as Shortcuts;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1315,11 +1315,6 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
   integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
 
-"@types/object.fromentries@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@types/object.fromentries/-/object.fromentries-2.0.0.tgz#8349ec6c51011a729da61e0c86ed433609a9f9a6"
-  integrity sha512-y/4Jx68CzO0Uh+SIbINo1gk+k8H1WVphZTHjMOpLdV3p5NqajFCMNKjg78c7YyCedmeIHyRRFhfcMuVZcWRE6g==
-
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"


### PR DESCRIPTION
Since most people seem to be on versions of Node that support this I figured we can remove this now. It can always be polyfilled by the consumer if that's still needed.